### PR TITLE
Add GetApp section with store buttons and responsive layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import GetApp from "@/components/GetApp";
 import Guide from "@/components/Guide";
 import Hero from "@/components/Hero";
 
+
 export default function Home() {
   return (
     <>

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+
+type ButtonProps = {
+  type: 'button' | 'submit';
+  title: string;
+  icon?: string;
+  variant: string;
+  full?: boolean;
+}
+
+const Button = ({ type, title, icon, variant, full }: ButtonProps) => {
+  return (
+    <button
+    className={`flexCenter gap-3 rounded-full border ${variant} ${full && 'w-full'}`}
+      type={type}
+    >
+      {icon && <Image src={icon} alt={title} width={24} height={24} />}
+      <label className="bold-16 whitespace-nowrap cursor-pointer">{title}</label>
+    </button>
+  )
+}
+
+export default Button

--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -1,0 +1,68 @@
+import { FEATURES } from '@/constants'
+import Image from 'next/image'
+import React from 'react'
+
+const Features = () => {
+  return (
+    <section className="flex-col flexCenter overflow-hidden bg-feature-bg bg-center bg-no-repeat py-24">
+      <div className="max-container padding-container relative w-full flex justify-end">
+        <div className="flex flex-1 lg:min-h-[900px]">
+          <Image
+            src="/phone.png"
+            alt="phone"
+            width={440}
+            height={1000}
+            className="feature-phone"
+          />
+        </div>
+
+        <div className="z-20 flex w-full flex-col lg:w-[60%]">
+          <div className='relative'>
+            <Image
+              src="/camp.svg"
+              alt="camp"
+              width={50}
+              height={50}
+              className="absolute left-[-5px] top-[-28px] w-10 lg:w-[50px]"
+            />
+            <h2 className="bold-40 lg:bold-64">Our Features</h2>
+          </div>
+          <ul className="mt-10 grid gap-10 md:grid-cols-2 lg:mg-20 lg:gap-20">
+            {FEATURES.map((feature) => (
+              <FeatureItem 
+                key={feature.title}
+                title={feature.title} 
+                icon={feature.icon}
+                description={feature.description}
+              />
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+type FeatureItem = {
+  title: string;
+  icon: string;
+  description: string;
+}
+
+const FeatureItem = ({ title, icon, description }: FeatureItem) => {
+  return (
+    <li className="flex w-full flex-1 flex-col items-start">
+      <div className="rounded-full p-4 lg:p-7 bg-green-50">
+        <Image src={icon} alt="map" width={28} height={28} />
+      </div>
+      <h2 className="bold-20 lg:bold-32 mt-5 capitalize">
+        {title}
+      </h2>
+      <p className="regular-16 mt-5 bg-white/80 text-gray-30 lg:mt-[30px] lg:bg-none">
+        {description}
+      </p>
+    </li>
+  )
+}
+
+export default Features

--- a/components/GetApp.tsx
+++ b/components/GetApp.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import Button from './Button'
+import Image from 'next/image'
+
+const GetApp = () => {
+  return (
+    <section className="flexCenter w-full flex-col pb-[100px]">
+      <div className="get-app">
+        <div className="z-20 flex w-full flex-1 flex-col items-start justify-center gap-12">
+          <h2 className="bold-40 lg:bold-64 xl:max-w-[320px]">Get for free now!</h2>
+          <p className="regular-16 text-gray-10">Available on iOS and Android</p>
+          <div className="flex w-full flex-col gap-3 whitespace-nowrap xl:flex-row">
+            <Button 
+              type="button"
+              title="App Store"
+              icon="/apple.svg"
+              variant="btn_white"
+              full
+            />
+            <Button 
+              type="button"
+              title="Play Store"
+              icon="/android.svg"
+              variant="btn_dark_green_outline"
+              full
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-1 items-center justify-end">
+          <Image src="/phones.png" alt="phones" width={550} height={870} />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default GetApp

--- a/components/Guide.tsx
+++ b/components/Guide.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image'
+import React from 'react'
+
+const Guide = () => {
+  return (
+    <section className="flexCenter flex-col">
+      <div className="padding-container max-container w-full pb-24">
+        <Image src="/camp.svg" alt="camp" width={50} height={50} />
+        <p className="uppercase regular-18 -mt-1 mb-3 text-green-50">
+          We are here for you
+        </p>
+        <div className="flex flex-wrap justify-between gap-5 lg:gap-10">
+          <h2 className="bold-40 lg:bold-64 xl:max-w-[390px]">Guide You to Easy Path</h2>
+          <p className="regular-16 text-gray-30 xl:max-w-[520px]">Only with the hilink application you will no longer get lost and get lost again, because we already support offline maps when there is no internet connection in the field. Invite your friends, relatives and friends to have fun in the wilderness through the valley and reach the top of the mountain</p>
+        </div>
+      </div>
+
+      <div className="flexCenter max-container relative w-full">
+        <Image 
+          src="/boat.png"
+          alt="boat"
+          width={1440}
+          height={580}
+          className="w-full object-cover object-center 2xl:rounded-5xl"
+        />
+
+        <div className="absolute flex bg-white py-8 pl-5 pr-7 gap-3 rounded-3xl border shadow-md md:left-[5%] lg:top-20">
+          <Image 
+            src="/meter.svg"
+            alt="meter"
+            width={16}
+            height={158}
+            className="h-full w-auto"
+          />
+          <div className="flexBetween flex-col">
+            <div className='flex w-full flex-col'>
+              <div className="flexBetween w-full">
+                <p className="regular-16 text-gray-20">Destination</p>
+                <p className="bold-16 text-green-50">48 min</p>
+              </div>
+              <p className="bold-20 mt-2">Aguas Calientes</p>
+            </div>
+
+            <div className='flex w-full flex-col'>
+              <p className="regular-16 text-gray-20">Start track</p>
+              <h4 className="bold-20 mt-2 whitespace-nowrap">Wonorejo Pasuruan</h4>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default Guide


### PR DESCRIPTION
This PR introduces a new GetApp section that promotes downloading the app for free on iOS and Android platforms. The section includes:

A headline and subtext with responsive typography

Two styled buttons linking to the App Store and Play Store using the Button component

An image of phones to visually represent the app

Responsive layout optimized for mobile and desktop (using flex and xl:flex-row)

Assets used:

apple.svg and android.svg icons

phones.png image